### PR TITLE
Add CONTRIBUTING.md to repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Try to do one pull request per change.
 5. Install the dependencies and start the development server
 
    ```sh
-    yarn
+   yarn
    yarn start
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contribution guidelines
+
+First off, thank you for considering contributing to unitycatalog-ui.
+
+We use [GitHub Issues](https://github.com/unitycatalog/unitycatalog-ui/issues) to track community-reported issues and [GitHub Pull Requests](https://github.com/unitycatalog/unitycatalog-ui/pulls) for accepting changes. If your contribution is not straightforward, please first discuss the change you wish to make by creating a new issue before making the change.
+
+## Reporting issues
+
+Before reporting an issue on the
+[issue tracker](https://github.com/unitycatalog/unitycatalog-ui/issues),
+please check that it has not already been reported by searching for some related
+keywords.
+
+## Pull requests
+
+Try to do one pull request per change.
+
+## How to Contribute
+
+1. [Fork](https://github.com/unitycatalog/unitycatalog-ui/fork) the repository on GitHub.
+2. Clone the forked repository to your local machine.
+
+   ```sh
+   git clone https://github.com/<your_github_username>/unitycatalog-ui.git
+   ```
+
+3. Get into the project directory
+
+   ```sh
+   cd unitycatalog-ui
+   ```
+
+4. Create your branch
+
+   ```sh
+   git checkout -b <your_branch_name>
+   ```
+
+5. Install the dependencies and start the development server
+
+   ```sh
+    yarn
+   yarn start
+   ```
+
+6. Make your changes: Commit your changes with clear and concise commit messages.
+7. Push your changes to your fork
+
+   ```sh
+   git push origin <your_branch_name>
+   ```
+
+8. Create a pull request to the `main` branch of the `unitycatalog/unitycatalog-ui` repository.


### PR DESCRIPTION
Add CONTRIBUTING.md with contribution guidelines

closes #26

I did a step-by-step instruction on how to contribute but if you prefer, I can do this instead:

## Developing

### Set up

```shell
git clone
cd unitycatalog-ui
yarn install
yarn start
```