### PR TITLE
remove all onSuccessCallback params

### DIFF
--- a/src/components/modals/CreateCatalogModal.tsx
+++ b/src/components/modals/CreateCatalogModal.tsx
@@ -6,6 +6,7 @@ import {
 import { useCallback, useRef } from 'react';
 import TextArea from 'antd/es/input/TextArea';
 import { useNavigate } from 'react-router-dom';
+import { useNotification } from '../../utils/NotificationContext';
 
 interface CreateCatalogModalProps {
   open: boolean;
@@ -17,11 +18,8 @@ export function CreateCatalogModal({
   closeModal,
 }: CreateCatalogModalProps) {
   const navigate = useNavigate();
-  const mutation = useCreateCatalog({
-    onSuccessCallback: (catalog) => {
-      navigate(`/data/${catalog.name}`);
-    },
-  });
+  const mutation = useCreateCatalog();
+  const { setNotification } = useNotification();
   const submitRef = useRef<HTMLButtonElement>(null);
 
   const handleSubmit = useCallback(() => {
@@ -45,7 +43,14 @@ export function CreateCatalogModal({
       <Form<CreateCatalogMutationParams>
         layout="vertical"
         onFinish={(values) => {
-          mutation.mutate(values);
+          mutation.mutate(values, {
+            onError: (error: Error) => {
+              setNotification(error.message, 'error');
+            },
+            onSuccess: (catalog) => {
+              navigate(`/data/${catalog.name}`);
+            },
+          });
         }}
         name="Create catalog form"
       >

--- a/src/components/modals/CreateSchemaModal.tsx
+++ b/src/components/modals/CreateSchemaModal.tsx
@@ -6,6 +6,7 @@ import {
   CreateSchemaMutationParams,
   useCreateSchema,
 } from '../../hooks/schemas';
+import { useNotification } from '../../utils/NotificationContext';
 
 interface CreateSchemaModalProps {
   open: boolean;
@@ -19,11 +20,8 @@ export default function CreateSchemaModal({
   catalog,
 }: CreateSchemaModalProps) {
   const navigate = useNavigate();
-  const mutation = useCreateSchema({
-    onSuccessCallback: (schema) => {
-      navigate(`/data/${schema.catalog_name}/${schema.name}`);
-    },
-  });
+  const mutation = useCreateSchema();
+  const { setNotification } = useNotification();
   const submitRef = useRef<HTMLButtonElement>(null);
 
   const handleSubmit = useCallback(() => {
@@ -47,7 +45,14 @@ export default function CreateSchemaModal({
       <Form<CreateSchemaMutationParams>
         layout="vertical"
         onFinish={(values) => {
-          mutation.mutate(values);
+          mutation.mutate(values, {
+            onError: (error) => {
+              setNotification(error.message, 'error');
+            },
+            onSuccess: (schema) => {
+              navigate(`/data/${schema.catalog_name}/${schema.name}`);
+            },
+          });
         }}
         name="Create schema form"
         initialValues={{ catalog_name: catalog }}

--- a/src/components/modals/DeleteCatalogModal.tsx
+++ b/src/components/modals/DeleteCatalogModal.tsx
@@ -17,12 +17,7 @@ export function DeleteCatalogModal({
 }: DeleteCatalogModalProps) {
   const navigate = useNavigate();
   const { setNotification } = useNotification();
-  const mutation = useDeleteCatalog({
-    onSuccessCallback: () => {
-      setNotification(`${catalog} catalog successfully deleted`, 'success');
-      navigate(`/`);
-    },
-  });
+  const mutation = useDeleteCatalog();
 
   const handleSubmit = useCallback(() => {
     mutation.mutate(
@@ -31,9 +26,13 @@ export function DeleteCatalogModal({
         onError: (error: Error) => {
           setNotification(error.message, 'error');
         },
+        onSuccess: () => {
+          setNotification(`${catalog} catalog successfully deleted`, 'success');
+          navigate(`/`);
+        },
       },
     );
-  }, [mutation, catalog, setNotification]);
+  }, [mutation, catalog, setNotification, navigate]);
 
   return (
     <Modal

--- a/src/components/modals/DeleteFunctionModal.tsx
+++ b/src/components/modals/DeleteFunctionModal.tsx
@@ -22,10 +22,6 @@ export function DeleteFunctionModal({
   const navigate = useNavigate();
   const { setNotification } = useNotification();
   const mutation = useDeleteFunction({
-    onSuccessCallback: () => {
-      setNotification(`${ucFunction} function successfully deleted`, 'success');
-      navigate(`/data/${catalog}/${schema}`);
-    },
     catalog,
     schema,
   });
@@ -37,9 +33,16 @@ export function DeleteFunctionModal({
         onError: (error: Error) => {
           setNotification(error.message, 'error');
         },
+        onSuccess: () => {
+          setNotification(
+            `${ucFunction} function successfully deleted`,
+            'success',
+          );
+          navigate(`/data/${catalog}/${schema}`);
+        },
       },
     );
-  }, [mutation, ucFunction, setNotification]);
+  }, [mutation, ucFunction, setNotification, navigate]);
 
   return (
     <Modal

--- a/src/components/modals/DeleteSchemaModal.tsx
+++ b/src/components/modals/DeleteSchemaModal.tsx
@@ -20,10 +20,6 @@ export function DeleteSchemaModal({
   const navigate = useNavigate();
   const { setNotification } = useNotification();
   const mutation = useDeleteSchema({
-    onSuccessCallback: () => {
-      setNotification(`${schema} schema successfully deleted`, 'success');
-      navigate(`/data/${catalog}`);
-    },
     catalog,
   });
 
@@ -34,9 +30,13 @@ export function DeleteSchemaModal({
         onError: (error: Error) => {
           setNotification(error.message, 'error');
         },
+        onSuccess: () => {
+          setNotification(`${schema} schema successfully deleted`, 'success');
+          navigate(`/data/${catalog}`);
+        },
       },
     );
-  }, [mutation, catalog, schema, setNotification]);
+  }, [mutation, catalog, schema, setNotification, navigate]);
 
   return (
     <Modal

--- a/src/components/modals/DeleteTableModal.tsx
+++ b/src/components/modals/DeleteTableModal.tsx
@@ -22,10 +22,6 @@ export function DeleteTableModal({
   const navigate = useNavigate();
   const { setNotification } = useNotification();
   const mutation = useDeleteTable({
-    onSuccessCallback: () => {
-      setNotification(`${table} table successfully deleted`, 'success');
-      navigate(`/data/${catalog}/${schema}`);
-    },
     catalog,
     schema,
   });
@@ -34,11 +30,22 @@ export function DeleteTableModal({
     [catalog, schema, table],
   );
   const handleSubmit = useCallback(() => {
-    mutation.mutate({
-      catalog_name: catalog,
-      schema_name: schema,
-      name: table,
-    });
+    mutation.mutate(
+      {
+        catalog_name: catalog,
+        schema_name: schema,
+        name: table,
+      },
+      {
+        onError: (error: Error) => {
+          setNotification(error.message, 'error');
+        },
+        onSuccess: () => {
+          setNotification(`${table} table successfully deleted`, 'success');
+          navigate(`/data/${catalog}/${schema}`);
+        },
+      },
+    );
   }, [mutation, catalog, schema, table]);
 
   return (

--- a/src/components/modals/DeleteVolumeModal.tsx
+++ b/src/components/modals/DeleteVolumeModal.tsx
@@ -22,10 +22,6 @@ export function DeleteVolumeModal({
   const navigate = useNavigate();
   const { setNotification } = useNotification();
   const mutation = useDeleteVolume({
-    onSuccessCallback: () => {
-      setNotification(`${volume} volume successfully deleted`, 'success');
-      navigate(`/data/${catalog}/${schema}`);
-    },
     catalog,
     schema,
   });
@@ -37,9 +33,13 @@ export function DeleteVolumeModal({
         onError: (error: Error) => {
           setNotification(error.message, 'error');
         },
+        onSuccess: () => {
+          setNotification(`${volume} volume successfully deleted`, 'success');
+          navigate(`/data/${catalog}/${schema}`);
+        },
       },
     );
-  }, [mutation, volume, setNotification]);
+  }, [mutation, volume, setNotification, navigate]);
 
   return (
     <Modal

--- a/src/hooks/catalog.tsx
+++ b/src/hooks/catalog.tsx
@@ -49,17 +49,11 @@ export function useGetCatalog({ catalog }: GetCatalogParams) {
 export interface CreateCatalogMutationParams
   extends Pick<CatalogInterface, 'name' | 'comment'> {}
 
-interface CreateCatalogParams {
-  onSuccessCallback?: (catalog: CatalogInterface) => void;
-}
-
 // Create a new catalog
-export function useCreateCatalog({
-  onSuccessCallback,
-}: CreateCatalogParams = {}) {
+export function useCreateCatalog() {
   const queryClient = useQueryClient();
 
-  return useMutation<CatalogInterface, unknown, CreateCatalogMutationParams>({
+  return useMutation<CatalogInterface, Error, CreateCatalogMutationParams>({
     mutationFn: async (params: CreateCatalogMutationParams) => {
       const response = await fetch(`${UC_API_PREFIX}/catalogs`, {
         method: 'POST',
@@ -74,11 +68,10 @@ export function useCreateCatalog({
       }
       return response.json();
     },
-    onSuccess: (catalog) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['listCatalogs'],
       });
-      onSuccessCallback?.(catalog);
     },
   });
 }
@@ -86,14 +79,8 @@ export function useCreateCatalog({
 export interface DeleteCatalogMutationParams
   extends Pick<CatalogInterface, 'name'> {}
 
-interface DeleteCatalogParams {
-  onSuccessCallback?: () => void;
-}
-
 // Delete a catalog
-export function useDeleteCatalog({
-  onSuccessCallback,
-}: DeleteCatalogParams = {}) {
+export function useDeleteCatalog() {
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, DeleteCatalogMutationParams>({
@@ -110,7 +97,6 @@ export function useDeleteCatalog({
       queryClient.invalidateQueries({
         queryKey: ['listCatalogs'],
       });
-      onSuccessCallback?.();
     },
   });
 }

--- a/src/hooks/functions.tsx
+++ b/src/hooks/functions.tsx
@@ -81,17 +81,12 @@ export interface DeleteFunctionMutationParams
   extends Pick<FunctionInterface, 'catalog_name' | 'schema_name' | 'name'> {}
 
 interface DeleteFunctionParams {
-  onSuccessCallback?: () => void;
   catalog: string;
   schema: string;
 }
 
 // Delete a function
-export function useDeleteFunction({
-  onSuccessCallback,
-  catalog,
-  schema,
-}: DeleteFunctionParams) {
+export function useDeleteFunction({ catalog, schema }: DeleteFunctionParams) {
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, DeleteFunctionMutationParams>({
@@ -118,7 +113,6 @@ export function useDeleteFunction({
       queryClient.invalidateQueries({
         queryKey: ['listFunctions', catalog, schema],
       });
-      onSuccessCallback?.();
     },
   });
 }

--- a/src/hooks/schemas.tsx
+++ b/src/hooks/schemas.tsx
@@ -58,16 +58,10 @@ export function useGetSchema({ catalog, schema }: GetSchemaParams) {
 export interface CreateSchemaMutationParams
   extends Pick<SchemaInterface, 'name' | 'catalog_name' | 'comment'> {}
 
-interface CreateSchemaParams {
-  onSuccessCallback?: (catalog: SchemaInterface) => void;
-}
-
-export function useCreateSchema({
-  onSuccessCallback,
-}: CreateSchemaParams = {}) {
+export function useCreateSchema() {
   const queryClient = useQueryClient();
 
-  return useMutation<SchemaInterface, unknown, CreateSchemaMutationParams>({
+  return useMutation<SchemaInterface, Error, CreateSchemaMutationParams>({
     mutationFn: async (params: CreateSchemaMutationParams) => {
       const response = await fetch(`${UC_API_PREFIX}/schemas`, {
         method: 'POST',
@@ -86,7 +80,6 @@ export function useCreateSchema({
       queryClient.invalidateQueries({
         queryKey: ['listSchemas', schema.catalog_name],
       });
-      onSuccessCallback?.(schema);
     },
   });
 }
@@ -95,14 +88,10 @@ export interface DeleteSchemaMutationParams
   extends Pick<SchemaInterface, 'catalog_name' | 'name'> {}
 
 interface DeleteSchemaParams {
-  onSuccessCallback?: () => void;
   catalog: string;
 }
 
-export function useDeleteSchema({
-  onSuccessCallback,
-  catalog,
-}: DeleteSchemaParams) {
+export function useDeleteSchema({ catalog }: DeleteSchemaParams) {
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, DeleteSchemaMutationParams>({
@@ -122,7 +111,6 @@ export function useDeleteSchema({
       queryClient.invalidateQueries({
         queryKey: ['listSchemas', catalog],
       });
-      onSuccessCallback?.();
     },
   });
 }

--- a/src/hooks/tables.tsx
+++ b/src/hooks/tables.tsx
@@ -76,19 +76,14 @@ export interface DeleteTableMutationParams
   extends Pick<TableInterface, 'catalog_name' | 'schema_name' | 'name'> {}
 
 interface DeleteTableParams {
-  onSuccessCallback?: () => void;
   catalog: string;
   schema: string;
 }
 
-export function useDeleteTable({
-  onSuccessCallback,
-  catalog,
-  schema,
-}: DeleteTableParams) {
+export function useDeleteTable({ catalog, schema }: DeleteTableParams) {
   const queryClient = useQueryClient();
 
-  return useMutation<void, unknown, DeleteTableMutationParams>({
+  return useMutation<void, Error, DeleteTableMutationParams>({
     mutationFn: async ({
       catalog_name,
       schema_name,
@@ -111,7 +106,6 @@ export function useDeleteTable({
       queryClient.invalidateQueries({
         queryKey: ['listTables', catalog, schema],
       });
-      onSuccessCallback?.();
     },
   });
 }

--- a/src/hooks/volumes.tsx
+++ b/src/hooks/volumes.tsx
@@ -74,17 +74,12 @@ export interface DeleteVolumeMutationParams
   extends Pick<VolumeInterface, 'catalog_name' | 'schema_name' | 'name'> {}
 
 interface DeleteVolumeParams {
-  onSuccessCallback?: () => void;
   catalog: string;
   schema: string;
 }
 
 // Delete a volume
-export function useDeleteVolume({
-  onSuccessCallback,
-  catalog,
-  schema,
-}: DeleteVolumeParams) {
+export function useDeleteVolume({ catalog, schema }: DeleteVolumeParams) {
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, DeleteVolumeMutationParams>({
@@ -111,7 +106,6 @@ export function useDeleteVolume({
       queryClient.invalidateQueries({
         queryKey: ['listVolumes', catalog, schema],
       });
-      onSuccessCallback?.();
     },
   });
 }


### PR DESCRIPTION
Removing all `onSuccessCallback` parameters in hooks, they are not needed and can be handled in mutation `onSuccess` instead.